### PR TITLE
feat: added a todo list for trivial tasks/tasks with no due date

### DIFF
--- a/components/DayTaskList.tsx
+++ b/components/DayTaskList.tsx
@@ -1,5 +1,5 @@
 import { FunctionComponent, useState, useContext } from "react";
-import { NotionTask } from "../types/notion-api";
+import { CalendarTask } from "../types/notion-api";
 import DayTask from "./DayTask";
 import { days } from "../util/dateTime";
 import { TasksContext } from "../util/contexts";
@@ -14,7 +14,7 @@ const DayTaskList: FunctionComponent<Props> = ({ dayOffset }) => {
   const todayTasks = allTasks.filter(
     (t) => new Date(t.dateISO).getDay() === (today + dayOffset) % 7
   );
-  const [tasks, setTasks] = useState<NotionTask[]>(todayTasks);
+  const [tasks, setTasks] = useState<CalendarTask[]>(todayTasks);
 
   return (
     <div className="flex flex-col flex-1 px-2 text-center">
@@ -38,7 +38,6 @@ const DayTaskList: FunctionComponent<Props> = ({ dayOffset }) => {
               typeId={task.typeId}
               label={task.label}
               url={task.url}
-              tasks={tasks}
               setTasks={setTasks}
             ></DayTask>
           );
@@ -50,7 +49,7 @@ const DayTaskList: FunctionComponent<Props> = ({ dayOffset }) => {
 
 // sort by ascending due date (soonest to latest)
 // using Date object primitive value
-const sortTasks = (a: NotionTask, b: NotionTask): number => {
+const sortTasks = (a: CalendarTask, b: CalendarTask): number => {
   let firstDate = new Date(a.dateISO).valueOf();
   let secondDate = new Date(b.dateISO).valueOf();
 

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -3,7 +3,7 @@ import { useSpring, animated } from "@react-spring/web";
 import { useModalContext } from "../util/contexts";
 
 const Modal = () => {
-  const { setModalOpenState } = useModalContext();
+  const { modalText, setModalOpen } = useModalContext();
   const [springs, api] = useSpring(() => ({
     from: {
       y: 10,
@@ -25,7 +25,7 @@ const Modal = () => {
         y: 10,
         opacity: 0,
       },
-      onRest: () => setModalOpenState(false),
+      onRest: () => setModalOpen(false),
     }));
   };
 
@@ -35,9 +35,7 @@ const Modal = () => {
       className="absolute bottom-6 bg-ctp-surface0 p-1 px-4 flex flex-row items-center"
       style={springs}
     >
-      <p className="font-[Kubasta] text-ctp-red text-lg">
-        Task completion unsuccessful. Try again.
-      </p>
+      <p className="font-[Kubasta] text-ctp-red text-lg">{modalText}</p>
       <FaTimes
         className="text-ctp-lavender ml-4 hover:cursor-pointer"
         onClick={handleCloseModal}

--- a/components/ToDoEntry.tsx
+++ b/components/ToDoEntry.tsx
@@ -4,10 +4,12 @@ import React, {
   SetStateAction,
   useState,
 } from "react";
-import { FaCheck } from "react-icons/fa";
 import { TodoTask } from "../types/notion-api";
 import { animated, useSpring } from "@react-spring/web";
 import { useModalContext } from "../util/contexts";
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSquare, faCheckSquare } from "@fortawesome/free-regular-svg-icons";
 
 type Props = {
   blockId: string;
@@ -16,13 +18,14 @@ type Props = {
 };
 
 const ToDoEntry: FunctionComponent<Props> = ({ blockId, text, setList }) => {
-  const [clicked, setClicked] = useState(false);
+  const [completed, setCompleted] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [springs, crossOut] = useSpring(() => ({
     from: {
       width: "0%",
     },
     config: {
-      friction: 50,
+      friction: 30,
     },
     onRest: () =>
       setList((current) => current.filter((t) => t.blockId !== blockId)),
@@ -31,9 +34,10 @@ const ToDoEntry: FunctionComponent<Props> = ({ blockId, text, setList }) => {
 
   const handleClick = async () => {
     try {
+      setLoading(true);
       await completeTodoRequest(blockId);
-
-      setClicked(true);
+      setLoading(false);
+      setCompleted(true);
       crossOut.start({
         from: {
           width: "0%",
@@ -44,24 +48,28 @@ const ToDoEntry: FunctionComponent<Props> = ({ blockId, text, setList }) => {
       });
     } catch (err) {
       console.error(err);
+      setLoading(false);
       setModalText("Todo task completion unsuccessful. Try again.");
       setModalOpen(true);
     }
   };
 
+  if (loading) {
+    return (
+      <div className="w-full flex justify-center">
+        <FontAwesomeIcon icon={faSpinner} spinPulse />
+      </div>
+    );
+  }
+
   return (
     <>
-      <div
-        onClick={handleClick}
-        className="w-4 h-4 border-ctp-lavender border-2 mr-2 text-center"
-      >
-        <FaCheck
-          className={`text-ctp-green text-xs ${
-            clicked ? "opacity-100" : "opacity-0"
-          }`}
-        />
-      </div>
-      <div className="relative">
+      {completed ? (
+        <FontAwesomeIcon icon={faCheckSquare} className="text-ctp-green" />
+      ) : (
+        <FontAwesomeIcon icon={faSquare} onClick={handleClick} />
+      )}
+      <div className="ml-3 relative">
         <animated.div
           className="absolute bg-ctp-lavender w-full h-[2px] top-1/2"
           style={springs}

--- a/components/ToDoEntry.tsx
+++ b/components/ToDoEntry.tsx
@@ -1,0 +1,92 @@
+import React, {
+  Dispatch,
+  FunctionComponent,
+  SetStateAction,
+  useState,
+} from "react";
+import { FaCheck } from "react-icons/fa";
+import { TodoTask } from "../types/notion-api";
+import { animated, useSpring } from "@react-spring/web";
+import { useModalContext } from "../util/contexts";
+
+type Props = {
+  blockId: string;
+  text: string;
+  setList: Dispatch<SetStateAction<TodoTask[]>>;
+};
+
+const ToDoEntry: FunctionComponent<Props> = ({ blockId, text, setList }) => {
+  const [clicked, setClicked] = useState(false);
+  const [springs, crossOut] = useSpring(() => ({
+    from: {
+      width: "0%",
+    },
+    config: {
+      friction: 50,
+    },
+    onRest: () =>
+      setList((current) => current.filter((t) => t.blockId !== blockId)),
+  }));
+  const { setModalText, setModalOpen } = useModalContext();
+
+  const handleClick = async () => {
+    try {
+      await completeTodoRequest(blockId);
+
+      setClicked(true);
+      crossOut.start({
+        from: {
+          width: "0%",
+        },
+        to: {
+          width: "100%",
+        },
+      });
+    } catch (err) {
+      console.error(err);
+      setModalText("Todo task completion unsuccessful. Try again.");
+      setModalOpen(true);
+    }
+  };
+
+  return (
+    <>
+      <div
+        onClick={handleClick}
+        className="w-4 h-4 border-ctp-lavender border-2 mr-2 text-center"
+      >
+        <FaCheck
+          className={`text-ctp-green text-xs ${
+            clicked ? "opacity-100" : "opacity-0"
+          }`}
+        />
+      </div>
+      <div className="relative">
+        <animated.div
+          className="absolute bg-ctp-lavender w-full h-[2px] top-1/2"
+          style={springs}
+        />
+        <span>{text}</span>
+      </div>
+    </>
+  );
+};
+
+async function completeTodoRequest(blockId: string) {
+  const response = await fetch("/api/todo", {
+    method: "POST",
+    body: JSON.stringify({
+      blockId: blockId,
+    }),
+    headers: new Headers({
+      "Content-Type": "application/json",
+    }),
+  });
+
+  const json = await response.json();
+  if (json.status !== "success") {
+    throw new Error("Todo task completion unsuccessful.");
+  }
+}
+
+export default ToDoEntry;

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -20,7 +20,7 @@ const TodoList: FunctionComponent<Props> = ({ todoList }) => {
       {transitions((style, item) => (
         <animated.div
           style={style}
-          className="text-ctp-text hover:cursor-pointer hover:font-bold flex flex-row items-center p-1 pl-2"
+          className="text-ctp-text hover:cursor-pointer hover:font-bold flex flex-row items-center p-1 pl-2 h-8"
         >
           <ToDoEntry
             key={item.blockId}

--- a/components/TodoList.tsx
+++ b/components/TodoList.tsx
@@ -1,0 +1,37 @@
+import { TodoTask } from "../types/notion-api";
+import { FunctionComponent, useState } from "react";
+import ToDoEntry from "./ToDoEntry";
+import { animated, useTransition } from "@react-spring/web";
+
+type Props = {
+  todoList: TodoTask[];
+};
+
+const TodoList: FunctionComponent<Props> = ({ todoList }) => {
+  const [list, setList] = useState<TodoTask[]>(todoList);
+  const transitions = useTransition(list, {
+    from: { opacity: 1, x: 0 },
+    leave: { opacity: 0, x: 40 },
+  });
+
+  return (
+    <div className="w-[350px] absolute top-4 right-4 font-[Kubasta] bg-ctp-base overflow-x-hidden">
+      <h1 className="text-2xl text-ctp-crust bg-ctp-lavender pl-2">to-do</h1>
+      {transitions((style, item) => (
+        <animated.div
+          style={style}
+          className="text-ctp-text hover:cursor-pointer hover:font-bold flex flex-row items-center p-1 pl-2"
+        >
+          <ToDoEntry
+            key={item.blockId}
+            blockId={item.blockId}
+            text={item.text}
+            setList={setList}
+          />
+        </animated.div>
+      ))}
+    </div>
+  );
+};
+
+export default TodoList;

--- a/next.config.js
+++ b/next.config.js
@@ -23,7 +23,20 @@ module.exports = {
         ]
       : () => [
           {
-            source: "/tasks/complete",
+            source: "/calendar",
+            headers: [
+              {
+                key: "Access-Control-Allow-Origin",
+                value: "https://api.notion.com",
+              },
+              {
+                key: "Access-Control-Allow-Methods",
+                value: "POST",
+              },
+            ],
+          },
+          {
+            source: "/todo",
             headers: [
               {
                 key: "Access-Control-Allow-Origin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,11 @@
     "": {
       "name": "startpage",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.5.0",
+        "@fortawesome/free-brands-svg-icons": "^6.5.0",
+        "@fortawesome/free-regular-svg-icons": "^6.5.0",
+        "@fortawesome/free-solid-svg-icons": "^6.5.0",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "@notionhq/client": "^2.2.13",
         "@react-spring/web": "^9.7.3",
         "babel-plugin-macros": "^3.1.0",
@@ -649,6 +654,75 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.5.0.tgz",
+      "integrity": "sha512-vYC8oN2l8meu05sRi1j3Iie/HNFAeIxpitYFhsUrBc11TxiMken9QdXnSQ0q16FYsOSt/6soxs5ghdk+VYGiog==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.5.0.tgz",
+      "integrity": "sha512-5DrR+oxQr+ruRQ3CEVV8DSCT/q8Atm56+FzAs0P6eW/epW47OmecSpSwc/YTlJ3u5BfPKUBSGyPR2qjZ+5eIgA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.5.0.tgz",
+      "integrity": "sha512-LwIl3b5cH0xjmBS7mcy8+SsSsl/7J4xi3aP+Tr4rDUf2Tab8r1c8NcqC8wP5c+bgphGstyG3QPx7l4b9WtcO5Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.5.0.tgz",
+      "integrity": "sha512-RaBW/y0jKcCyEPM+NYuBs3bQXuLYZHnXABQPmg6qwuRxNb2EUmyCcVUECUH2dkFmMjggh/xvl6n6y62Pl19JkA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.5.0.tgz",
+      "integrity": "sha512-6ZPq8mme67Q7O9Fbp2O+Z7mPZbcWTsRv555JLftLaTodiV0Wq+99YgMhyQ8O6mgNQfComqS9OEvqs7M8ySA92g==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.5.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -3886,7 +3960,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4349,7 +4422,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -4419,8 +4491,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,11 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.5.0",
+    "@fortawesome/free-brands-svg-icons": "^6.5.0",
+    "@fortawesome/free-regular-svg-icons": "^6.5.0",
+    "@fortawesome/free-solid-svg-icons": "^6.5.0",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "@notionhq/client": "^2.2.13",
     "@react-spring/web": "^9.7.3",
     "babel-plugin-macros": "^3.1.0",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,8 +1,9 @@
-import { AppProps } from 'next/app'
-import '../styles/globals.css'
+import { AppProps } from "next/app";
+import "../styles/globals.css";
+import "@fortawesome/fontawesome-svg-core/styles.css";
 
 function MyApp({ Component, pageProps }: AppProps) {
-  return <Component {...pageProps} />
+  return <Component {...pageProps} />;
 }
 
-export default MyApp
+export default MyApp;

--- a/pages/api/calendar.ts
+++ b/pages/api/calendar.ts
@@ -1,17 +1,17 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { isCompleteTaskRequest, notion } from "../../../util/notion-api";
-import { TaskCompleteResponse } from "../../../types";
+import { isCalendarCompleteRequest, notion } from "../../util/notion-api";
+import { CalendarCompleteRequest, CalendarCompleteResponse } from "../../types";
 
 export default async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse<TaskCompleteResponse>
+  req: CalendarCompleteRequest,
+  res: NextApiResponse<CalendarCompleteResponse>
 ) {
   try {
-    if (!isCompleteTaskRequest(req)) {
+    if (!isCalendarCompleteRequest(req)) {
       throw new Error("Notion page ID was not given or was not a string.");
     }
 
-    const response = await notion.pages.update({
+    await notion.pages.update({
       page_id: req.body.pageId,
       properties: {
         Done: {
@@ -22,19 +22,17 @@ export default async function handler(
 
     return res.status(200).json({
       status: "success",
-      data: {
-        page: response,
-      },
+      data: null
     });
   } catch (err: unknown) {
     if (err instanceof Error) {
-      return res.status(403).json({
+      return res.status(400).json({
         status: "error",
         message: err.message,
       });
     }
 
-    return res.status(403).json({
+    return res.status(500).json({
       status: "error",
       message: "Unknown error occurred.",
     });

--- a/pages/api/todo.ts
+++ b/pages/api/todo.ts
@@ -1,0 +1,38 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { isTodoCompleteRequest, notion } from "../../util/notion-api";
+import { TodoCompleteResponse } from "../../types";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<TodoCompleteResponse>
+) {
+  try {
+    if (!isTodoCompleteRequest(req)) {
+      throw new Error("Notion block ID was not given or was not a string.");
+    }
+
+    await notion.blocks.update({
+        block_id: req.body.blockId,
+        to_do: {
+            checked: true
+        }
+    })
+
+    return res.status(200).json({
+      status: "success",
+      data: null,
+    });
+  } catch (err: unknown) {
+    if (err instanceof Error) {
+      return res.status(400).json({
+        status: "error",
+        message: err.message,
+      });
+    }
+
+    return res.status(500).json({
+      status: "error",
+      message: "Unknown error occurred.",
+    });
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -18,7 +18,7 @@ body {
 }
 
 #__next {
-  @apply h-screen w-screen flex flex-col justify-center items-center;
+  @apply h-screen w-screen flex flex-col justify-center items-center overflow-x-hidden;
 }
 
 body {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,24 +1,37 @@
 import { UpdatePageResponse } from "@notionhq/client/build/src/api-endpoints";
 import { NextApiRequest } from "next";
 
-export type TaskCompleteSuccessResponse = {
+type CalendarCompleteSuccessResponse = {
   status: "success";
-  data: {
-    page: UpdatePageResponse;
-  };
+  data: null;
 };
 
-export type TaskCompleteFailResponse = {
+type TodoCompleteSuccessResponse = {
+  status: "success";
+  data: null
+}
+
+type ErrorResponse = {
   status: "error";
   message: string;
 };
 
-export type TaskCompleteResponse =
-  | TaskCompleteSuccessResponse
-  | TaskCompleteFailResponse;
+export type CalendarCompleteResponse =
+  | CalendarCompleteSuccessResponse
+  | ErrorResponse;
 
-export interface CompleteTaskRequest extends NextApiRequest {
+export type TodoCompleteResponse = 
+  | TodoCompleteSuccessResponse
+  | ErrorResponse;
+
+export interface CalendarCompleteRequest extends NextApiRequest {
   body: {
     pageId: string;
   };
+}
+
+export interface TodoCompleteRequest extends NextApiRequest {
+  body: {
+    blockId: string;
+  }
 }

--- a/types/notion-api.ts
+++ b/types/notion-api.ts
@@ -3,7 +3,7 @@ import {
   RichTextItemResponse,
 } from "@notionhq/client/build/src/api-endpoints";
 
-export type NotionTask = {
+export type CalendarTask = {
   pageId: string;
   url: string;
   dateISO: string;
@@ -11,6 +11,11 @@ export type NotionTask = {
   label: string;
   title: string;
 };
+
+export type TodoTask = {
+  blockId: string;
+  text: string;
+}
 
 export type CalendarPageObjectResponse = Omit<
   PageObjectResponse,

--- a/util/contexts.ts
+++ b/util/contexts.ts
@@ -1,10 +1,13 @@
-import { createContext, useContext } from "react";
-import { NotionTask } from "../types/notion-api";
+import { createContext, useContext, Dispatch, SetStateAction } from "react";
+import { CalendarTask } from "../types/notion-api";
 
-export const TasksContext = createContext<NotionTask[]>([]);
+export const TasksContext = createContext<CalendarTask[]>([]);
 
 type ModalContextType = {
-  setModalOpenState: React.Dispatch<React.SetStateAction<boolean>>;
+  setModalOpen: Dispatch<SetStateAction<boolean>>;
+  modalText: string;
+  setModalText: Dispatch<SetStateAction<string>>;
+  
 };
 export const ModalContext = createContext<ModalContextType | undefined>(
   undefined

--- a/util/notion-api.ts
+++ b/util/notion-api.ts
@@ -1,8 +1,8 @@
-import { DatabaseObjectResponse, PageObjectResponse } from "@notionhq/client/build/src/api-endpoints";
+import { BlockObjectResponse, DatabaseObjectResponse, PageObjectResponse, ToDoBlockObjectResponse } from "@notionhq/client/build/src/api-endpoints";
 import { CalendarPageObjectResponse } from "../types/notion-api";
 import { Client } from "@notionhq/client";
 import { NextApiRequest } from "next";
-import { CompleteTaskRequest } from "../types";
+import { CalendarCompleteRequest, TodoCompleteRequest } from "../types";
 
 export const notion = new Client({ auth: process.env.NOTION_TOKEN });
 
@@ -35,10 +35,28 @@ export function isCalendarPage(
   return true;
 }
 
-export function isCompleteTaskRequest(
-  request: NextApiRequest
-): request is CompleteTaskRequest {
-  if (!request.body.pageId || typeof request.body.pageId !== "string") {
+export function isTodoListBlock(
+  res: BlockObjectResponse
+): res is ToDoBlockObjectResponse {
+  if (!res.type || res.type !== "to_do") {
+    return false;
+  }
+  
+  return true;
+}
+
+export function isCalendarCompleteRequest(
+  req: NextApiRequest
+): req is CalendarCompleteRequest {
+  if (!req.body.pageId || typeof req.body.pageId !== "string") {
+    return false;
+  }
+
+  return true;
+}
+
+export function isTodoCompleteRequest(req: NextApiRequest): req is TodoCompleteRequest {
+  if (!req.body.blockId || typeof req.body.blockId !== "string") {
     return false;
   }
 


### PR DESCRIPTION
I added a to-do list with checkboxes in the top right for tasks that are trivial or things I have to do today that don't have a specific due date, stuff like buying groceries, etc.

This to-do list is completely synced with my Notion to-do list. On the initial load, the page fetches my Notion to-do list to display. When completing a to-do task on my start page, it also completes on my Notion to-do list.

It is fully animated on interaction:
- text is bolded on hover to tell me which task is being interacted with
- when a task's checkbox is clicked, a loading spinner animation plays while the task is attempted to be marked completed. If it fails, an error message popup shows at the bottom of the screen.
- A nice strikethrough text and fade-out animation plays when a task is completed.